### PR TITLE
Don't specificy tabWidth for markdown in default config

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -53,14 +53,6 @@ commands:
             if [ ! -e ".prettierrc.json" ]; then
             	cat > .prettierrc.json \<<-'EOF'
             		{
-            		  "overrides": [
-            		    {
-            		      "files": ["**/*.md"],
-            		      "options": {
-            		        "tabWidth": 4
-            		      }
-            		    }
-            		  ],
             		  "printWidth": 99,
             		  "proseWrap": "always"
             		}


### PR DESCRIPTION
Formatting follows editorconfig, so there is no need to specify
tabWidth for markdown for our usecase.