### PR TITLE
Cleanup old test tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,10 @@ jobs:
             git config --global user.name "$CIRCLE_USERNAME"
             git remote set-url origin "https://${GH_TOKEN}@github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
       - run:
+          name: Cleanup old test tags
+          command: |
+            ./helpers/cleanup_old_test_tags.py
+      - run:
           name: Replace config with second stage
           command: |
             sed "s/@@orb-revision@@/${CIRCLE_SHA1:0:7}/g" < .circleci/stage2.yml > .circleci/config.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           name: Create tag and push it
           command: |
             if [ -n "${CIRCLE_TAG}" ]; then
-                INTEGRATION_TAG="release-${CIRCLE_TAG}-${CIRCLE_SHA1:0:7}"
+                INTEGRATION_TAG="release-${CIRCLE_TAG}"
             else
                 INTEGRATION_TAG="test-${CIRCLE_BRANCH}-${CIRCLE_SHA1:0:7}"
             fi

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 .prettierignore
 helpers/await_builds_for_tag.py
+helpers/cleanup_old_test_tags.py
 helpers/requirements.txt

--- a/helpers/cleanup_old_test_tags.py
+++ b/helpers/cleanup_old_test_tags.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+from subprocess import check_call, check_output, CalledProcessError
+from time import time
+
+
+def is_tag_old(tag):
+    tag_info = (
+        check_output(
+            [
+                "git",
+                "for-each-ref",
+                "--format=%(taggerdate:unix)",
+                "refs/tags/{}".format(tag),
+            ]
+        )
+        .decode("utf8")
+        .strip()
+    )
+    if not tag_info:
+        # Happens if the tag is not an annotated tag
+        tag_info = (
+            check_output(["git", "show", "--no-patch", "--pretty=format:%at", tag])
+            .decode("utf8")
+            .strip()
+        )
+    tag_timestamp = int(tag_info)
+    return time() - tag_timestamp >= 86400
+
+
+def find_old_test_tags():
+    old_test_tags = []
+    for tag in check_output(["git", "tag"]).decode("utf8").splitlines():
+        if not tag.startswith("test-"):
+            continue
+        if not is_tag_old(tag):
+            continue
+        old_test_tags.append(tag)
+    return old_test_tags
+
+
+def cleanup_old_test_tags():
+    check_call(["git", "fetch"])
+    tags_to_clean = find_old_test_tags()
+    try:
+        check_call(["git", "push", "origin", "--delete"] + tags_to_clean)
+    except CalledProcessError:
+        # Ignore failures here, multiple instances might try to delete
+        # tags at the same time.
+        pass
+    check_call(["git", "tag", "--delete"] + tags_to_clean)
+
+
+if __name__ == "__main__":
+    cleanup_old_test_tags()


### PR DESCRIPTION
We should ensure that the tags created for testing are not kept around forever.

Implement this by deleting any tags matching the test pattern which are older than a day.