### PR TITLE
Ignore untracked files for write-commit-push

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -78,13 +78,14 @@ commands:
             else
                 REMOTE_URL="<< parameters.remote-url >>"
             fi
-            if [ -n "$(git status --porcelain)" ]; then
+            if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
                 git commit --all --message "Format code with Prettier"
                 git push "$REMOTE_URL" "HEAD:${CIRCLE_BRANCH}"
-                # Indicate failure if we needed to fix formatting
+                echo "We fixed formatting and pushed a commit." >&2
+                echo "Testing will continue at that commit, so indicating failure here. ♻" >&2
                 exit 1
             else
-                echo "No changes to commit."
+                echo "No changes to commit, everything is pretty. ✨" >&2
             fi
 
 jobs:


### PR DESCRIPTION
If we add our default `.prettierrc.json` to the repository because the
original repository does not provide one, it will show up as untracked
file in `git status --porcelain`.

Since we don't want to trigger a commit when this untracked file is the
only reason for a dirty status, ignore untracked files when deciding
whether a commit is needed.